### PR TITLE
Small adjustments to schemas

### DIFF
--- a/schemas/README.md
+++ b/schemas/README.md
@@ -37,10 +37,13 @@ prop --unit--> ont
 ```
 
 When only considering the core "functionality" of ISA, seven types need to be mapped: `Study`/`Assay` (merged since they both represent a process sequence with additional metadata), `Process`, `Protocol`, `Source`/`Sample` (merged since a source is a sample without factors), `Data`, `OntologyAnnotation`, and `ParameterValue` (representing all forms of values, e.g. `FactorValue`, `MaterialAttributeValue`, etc.).
+
 `Study`/`Assay` should be a `Dataset`, as required by RO-Crate.
 `Data` should be a `MediaObject`/`File`, again as required by RO-Crate.
+
 For `Material`, the type `BioSample` already exists in bioschemas.
 An `OntologyAnnotation` can be mapped to `DefinedTerm` and a `ParameterValue` to `PropertyValue`.
+
 Apart from the process sequence, only minor changes are necessary for these types (more details later).
 Mapping the process sequence is the core problem, which we explain now.
 
@@ -55,6 +58,7 @@ It can also interpreted as a `ProcessSequence`, considering the `step` property.
 For a `Process` the following concepts are missing:
 - `output`/"sampleProduced"
 - `parameters` and their values
+- `inputs` and `outputs` might both either be physical entities (samples) or digital entities (data)
 - maybe executed protocol
 
 For a Protocol the following concepts are missing:
@@ -67,7 +71,17 @@ Further minor problems when mapping these ISA types to a LabProtocol:
 
 ## Parameter Values
 
-`ParameterValues` in ISA are very generic key-value pairs. Thus, the `PropertyValue` type seems to fit well. However, in schema.org, only the key (`valueReference`) can be an ontology annotation (`DefinedTerm`). In ISA, the value and the unit can also be ontology terms (e.g. an organism). In a `PropertyValue`, the value can only be `StructuredValue`, not `DefinedTerm`. The unit only has a code and a text, not an ontology reference.
+`ParameterValues` in ISA are very generic key-value pairs. Thus, the `PropertyValue` type seems to fit well. 
+
+However, in schema.org, only the key (`valueReference`) can be an ontology annotation (`DefinedTerm`). In ISA, the value and the unit can also be ontology terms. 
+
+- E.g.: For a given key [organism](http://purl.obolibrary.org/obo/OBI_0100026), the value might be [Arabidopsis thaliana](https://ontobee.org/ontology/NCBITaxon?iri=http://purl.obolibrary.org/obo/NCBITaxon_3702).
+- E.g.: For a given key [temperature](http://purl.obolibrary.org/obo/PATO_0000146), the value might have the unit [degree Celsius](http://purl.obolibrary.org/obo/UO_0000027).
+
+In a `PropertyValue`, the value can only be `StructuredValue`, not `DefinedTerm`. The unit only has a code and a text, not an ontology reference.
+
+
+
 
 Our desired schema for `PropertyValue` would look like this:
 ```JSON

--- a/schemas/process_schema.md
+++ b/schemas/process_schema.md
@@ -1,17 +1,17 @@
-# ExperimentalProcess Type
+# Process Type
 
 ## Schema.org hierarchy
 
 This is a new Type that fits into the schema.org hierarchy as follows:
-[Thing](http://schema.org/Thing) > [CreativeWork](http://schema.org/Creativework) > [ExperimentalProcess](https://isa-specs.readthedocs.io/en/latest/isajson.html#process-schema-json)
+[Thing](http://schema.org/Thing) > [CreativeWork](http://schema.org/Creativework) > [Process](https://isa-specs.readthedocs.io/en/latest/isajson.html#process-schema-json)
 
 ## Description
 
-A process represents the application of a protocol to some input material (a sample or a source) to produce some output (sample, source or data file).
+A process represents the specific application of a protocol to some input material (a sample or a source) to produce some output (sample, source or data file).
 
 ## Properties
 
-- [`ExperimentalProcess`](https://isa-specs.readthedocs.io/en/latest/isajson.html#process-schema-json)
+- [`Process`](https://isa-specs.readthedocs.io/en/latest/isajson.html#process-schema-json)
   - [`name`](): [`Text`](https://schema.org/Text)
   - [`creator`](http://schema.org/Creator): [`Person`](https://schema.org/Person) or [`Organization`](https://schema.org/Organization)
   - [`dateCreated`](http://schema.org/dateCreated): [`Date`](https://schema.org/Date)

--- a/schemas/propertyvalue_schema.md
+++ b/schemas/propertyvalue_schema.md
@@ -7,7 +7,8 @@ This is a new Type that fits into the schema.org hierarchy as follows:
 
 ## Description
 
-A property value describes the value of a attribute or (protocol) parameter, given a sample or an executed instance (ExperimentalProcess) of a protocol. In contrast to a schema.org [PropertyValue](http://schema.org/PropertyValue), not only the [valueReference](http://schema.org/valueReference)/category can be a ontology term ([DefinedTerm](http://schema.org/DefinedTerm)), but also the actual [value](http://schema.org/value) and unit.
+A property value describes the value of a attribute or (protocol) parameter, given a sample or an executed instance (Process) of a protocol. In contrast to a schema.org [PropertyValue](http://schema.org/PropertyValue), not only the [valueReference](http://schema.org/valueReference)(category) can be an ontology term ([DefinedTerm](http://schema.org/DefinedTerm)), but also the actual [value](http://schema.org/value) and unit.
+
 
 ## Properties
 

--- a/schemas/protocol_schema.md
+++ b/schemas/protocol_schema.md
@@ -1,18 +1,18 @@
-# ExperimentalProtocol Type
+# Protocol Type
 
 ## Schema.org hierarchy
 
 This is a new Type that fits into the schema.org hierarchy as follows:
-[Thing](http://schema.org/Thing) > [CreativeWork](http://schema.org/CreativeWork) > [ExperimentalProtocol](https://isa-specs.readthedocs.io/en/latest/isajson.html#protocol-schema-json)
+[Thing](http://schema.org/Thing) > [CreativeWork](http://schema.org/CreativeWork) > [Protocol](https://isa-specs.readthedocs.io/en/latest/isajson.html#protocol-schema-json)
 
 ## Description
 
-ToDo
+A protocol represents the abstraction of a scientific workflow. It describes and parametrizes the atomic steps needed to perform this workflow.
 
 ## Properties
 
 ToDo:
-- [`ExperimentalProtocol`](https://isa-specs.readthedocs.io/en/latest/isajson.html#process-schema-json)
+- [`Protocol`](https://isa-specs.readthedocs.io/en/latest/isajson.html#process-schema-json)
   - [`name`](): [`Text`](https://schema.org/Text)
   - [`protocolType`](): [`DefinedTerm`](https://schema.org/DefinedTerm)
   - [`description`](https://schema.org/description): [`Text`](https://schema.org/Text)


### PR DESCRIPTION
- Removed "Experimental" prefix from `Protocol` and `Process`.
  As they can both carry `data` instead of `samples` as input and output, the name should reflect this generalization
- Added description to `Protocol` schema
- Added examples to `PropertyValue` explanation
- Other minor fixes